### PR TITLE
Protect the '/' route if the user is logged in

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -5,5 +5,12 @@ module.exports = {
     } else {
       res.redirect("/");
     }
+  },
+  ensureGuest: function (req, res, next) {
+    if (req.isAuthenticated()) {
+      res.redirect("/feed");
+    } else {
+      return next();
+    }
   }
 };

--- a/routes/main.js
+++ b/routes/main.js
@@ -4,10 +4,10 @@ const upload = require("../middleware/multer");
 const authController = require("../controllers/auth");
 const homeController = require("../controllers/home");
 const mainController = require("../controllers/main");
-const { ensureAuth } = require("../middleware/auth");
+const { ensureAuth, ensureGuest } = require("../middleware/auth");
 
 //Main Routes 
-router.get("/", homeController.getIndex);
+router.get("/", ensureGuest, homeController.getIndex);
 router.get("/profile/:id", ensureAuth, mainController.getProfile);
 router.get("/customizeProfile", ensureAuth, mainController.getCustomizeProfile);
 router.put("/customizeProfile", upload.single("file"), mainController.putCustomizeProfile);


### PR DESCRIPTION
Added and exported ensureGuest middleware to /middleware/auth.js, the ensureGuest middleware checks if a user is logged in (i.e has a session stored) and then redirects the user to the feed route and if the user is not logged in then it runs normally.

Then imported the ensureGuest middleware to route/main.js, then added it to the route that loads the landing page '/'.

This protects the '/' route by redirecting already logged-in users to the feed route when they try to access the '/' route making it so that only new user or existing user that have logged out have access to the '/' route or landing page