### PR TITLE
Bug: added a line of code in server.js so that Vercel can access the views folder

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,6 +26,9 @@ app.set("view engine", "ejs");
 //Static Folder
 app.use(express.static(path.join(__dirname, "public")));
 
+// Gives the hosting service access to the views directory
+app.set('views', path.join(__dirname, 'views'))
+
 //Body Parsing
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());


### PR DESCRIPTION

# Description

After hosting the code on **Vercel**, it crashed because of an error which was caused because **Vercel** was unable to access the `views `directory. The line of code added would solve the problem and give access to **Vercel**

Fixes #34

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Test update
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update